### PR TITLE
Load Google credentials from uploaded JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ The app will open in your browser at `http://localhost:8501`
 
 ### First Time Setup
 
-1. **Paste Credentials**: In the sidebar, paste the entire contents of your Google Service Account JSON file
+1. **Upload Credentials File**: In the sidebar, upload the Google Service Account JSON file you downloaded from Google Cloud Console
 2. **Enter Sheet Name**: Confirm or modify the Google Sheet name (default: "Transactions")
 3. **Click Refresh**: The app will load your transactions and fetch current market data
 
@@ -225,12 +225,17 @@ client_x509_cert_url = "your-cert-url"
 5. Update `app.py` to use secrets:
 
 ```python
-# In app.py, replace credentials input with:
-if st.secrets.get("google_credentials"):
+# In app.py, load credentials from Streamlit secrets when available:
+if "google_credentials" in st.secrets:
     credentials_dict = dict(st.secrets["google_credentials"])
 else:
-    # Fallback to manual input for local development
-    credentials_json = st.sidebar.text_area(...)
+    credentials_file = config.get("credentials_file")
+    if credentials_file is None:
+        show_setup_instructions()
+        return
+
+    credentials_data = credentials_file.getvalue().decode("utf-8")
+    credentials_dict = json.loads(credentials_data)
 ```
 
 ## ❓ Troubleshooting
@@ -238,7 +243,7 @@ else:
 ### "Error connecting to Google Sheets"
 - Verify your JSON credentials are valid and properly formatted
 - Ensure the Google Sheets API is enabled in your Google Cloud project
-- Check that you've pasted the complete JSON (starts with `{` and ends with `}`)
+- Check that you've uploaded a complete JSON file (starts with `{` and ends with `}`)
 
 ### "Error loading transactions"
 - Check that your Google Sheet is named correctly

--- a/app.py
+++ b/app.py
@@ -28,17 +28,27 @@ def main():
     # Render sidebar and get configuration
     config = render_sidebar()
 
-    # Check if credentials are provided
-    if not config['credentials_json']:
-        show_setup_instructions()
-        return
+    # Determine credentials source
+    credentials_dict = None
 
-    # Parse credentials
-    try:
-        credentials_dict = json.loads(config['credentials_json'])
-    except json.JSONDecodeError:
-        st.error("❌ Invalid JSON format for credentials. Please check and try again.")
-        return
+    if "google_credentials" in st.secrets:
+        credentials_dict = dict(st.secrets["google_credentials"])
+    else:
+        credentials_file = config.get('credentials_file')
+        if credentials_file is None:
+            show_setup_instructions()
+            return
+
+        # Parse credentials from uploaded file
+        try:
+            credentials_data = credentials_file.getvalue().decode("utf-8")
+            credentials_dict = json.loads(credentials_data)
+        except UnicodeDecodeError:
+            st.error("❌ Unable to read the uploaded file. Please ensure it is a valid JSON file.")
+            return
+        except json.JSONDecodeError:
+            st.error("❌ Invalid JSON format for credentials. Please check and try again.")
+            return
 
     # Initialize portfolio manager
     portfolio_manager = PortfolioManager(

--- a/ui/components.py
+++ b/ui/components.py
@@ -10,7 +10,7 @@ from typing import List
 
 def show_setup_instructions():
     """Display setup instructions when credentials are not provided"""
-    st.info("👈 Please provide your Google Sheets credentials in the sidebar to get started.")
+    st.info("👈 Please upload your Google Sheets service account JSON file in the sidebar to get started.")
 
     st.markdown("""
     ### 🚀 Setup Instructions

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -25,12 +25,14 @@ def render_sidebar() -> Dict:
         st.header("⚙️ Configuration")
 
         st.subheader("🔐 Google Sheets Credentials")
-        credentials_json = st.text_area(
-            "Paste your Service Account JSON:",
-            height=200,
-            help="Get this from Google Cloud Console > IAM & Admin > Service Accounts",
-            placeholder='{"type": "service_account", ...}'
+        credentials_file = st.file_uploader(
+            "Upload your Service Account JSON:",
+            type=["json"],
+            help="Upload the JSON key file downloaded from Google Cloud Console > IAM & Admin > Service Accounts"
         )
+
+        if credentials_file is not None:
+            st.caption(f"✅ Loaded credentials file: {credentials_file.name}")
 
         st.subheader("📊 Sheet Configuration")
         sheet_name = st.text_input(
@@ -46,7 +48,7 @@ def render_sidebar() -> Dict:
         st.caption("💡 Your credentials are never stored or shared")
 
     return {
-        'credentials_json': credentials_json,
+        'credentials_file': credentials_file,
         'sheet_name': sheet_name,
         'refresh_requested': refresh_button
     }


### PR DESCRIPTION
## Summary
- replace the sidebar text area with a JSON file uploader for Google service account credentials
- fall back to Streamlit secrets when available and improve error handling for malformed files
- refresh the setup instructions and documentation to describe the new credential workflow

## Testing
- not run (Streamlit dependency unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd826c0768832ea35d0d9ac8364e19