### PR TITLE
Add configurable workbook settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ uv pip install -e .
 ⚠️ **IMPORTANT**: Keep this JSON file secure! Add it to `.gitignore` and never commit it to version control.
 
 #### c) Share Your Google Sheet
-1. Open your Google Sheet named "Transactions"
+1. Open your Google Sheet (defaults to "Transactions" unless you configured a different workbook name)
 2. Click the **Share** button
 3. Add the service account email from the JSON file (looks like: `xxx@xxx.iam.gserviceaccount.com`)
 4. Give it **Viewer** access
@@ -92,7 +92,7 @@ uv pip install -e .
 
 ### 4. Prepare Your Google Sheet
 
-Your Google Sheet should be named **"Transactions"** and have a tab also named **"Transactions"** with these columns:
+Your Google Sheet must have a worksheet/tab named **"Transactions"** with these columns. The workbook itself defaults to **"Transactions"**, but you can override that name via configuration (see below).
 
 | Column | Description | Example |
 |--------|-------------|---------|
@@ -124,6 +124,16 @@ streamlit run app.py
 
 The app will open in your browser at `http://localhost:8501`
 
+### 🔧 Configure the Workbook Name (Optional)
+
+The app reads transactions from the worksheet **"Transactions"**. The Google Sheets workbook defaults to the same name, but you can override it without changing code:
+
+- **Streamlit secrets**: add `workbook_name = "My Portfolio"` to `.streamlit/secrets.toml`.
+- **Environment variable**: export `PORTFOLIO_WORKBOOK_NAME="My Portfolio"` before launching Streamlit.
+- **JSON file**: create `config/workbook.json` (make the `config/` folder if needed) containing `{ "workbook_name": "My Portfolio" }`.
+
+The current workbook name is displayed in the sidebar under **Sheet Configuration** for quick verification.
+
 ## 🔐 Security & Privacy
 
 ### Credentials Are Never Stored
@@ -145,8 +155,7 @@ The app will open in your browser at `http://localhost:8501`
 ### First Time Setup
 
 1. **Upload Credentials File**: In the sidebar, upload the Google Service Account JSON file you downloaded from Google Cloud Console
-2. **Enter Sheet Name**: Confirm or modify the Google Sheet name (default: "Transactions")
-3. **Click Refresh**: The app will load your transactions and fetch current market data
+2. **Click Refresh**: The app will load your transactions and fetch current market data using the configured workbook name
 
 ### Understanding the Dashboard
 

--- a/app.py
+++ b/app.py
@@ -53,7 +53,7 @@ def main():
     # Initialize portfolio manager
     portfolio_manager = PortfolioManager(
         credentials_dict=credentials_dict,
-        sheet_name=config['sheet_name']
+        workbook_name=config.get('workbook_name')
     )
 
     # Render dashboard

--- a/core/portfolio.py
+++ b/core/portfolio.py
@@ -6,28 +6,30 @@ import pandas as pd
 from typing import Dict, Optional
 from data.google_sheets import GoogleSheetsClient
 from data.market_data import MarketDataProvider
+from utils.config import WORKBOOK_NAME
 
 
 class PortfolioManager:
     """Manages portfolio data and calculations"""
 
-    def __init__(self, credentials_dict: Dict, sheet_name: str):
+    def __init__(self, credentials_dict: Dict, workbook_name: Optional[str] = None):
         """
         Initialize portfolio manager
 
         Args:
             credentials_dict: Google service account credentials
-            sheet_name: Name of the Google Sheet
+            workbook_name: Optional override for the Google Sheets workbook
+                name. If omitted, the configured workbook name is used.
         """
         self.sheets_client = GoogleSheetsClient(credentials_dict)
         self.market_data = MarketDataProvider()
-        self.sheet_name = sheet_name
+        self.workbook_name = workbook_name or WORKBOOK_NAME
         self._transactions_df: Optional[pd.DataFrame] = None
         self._positions: Optional[Dict] = None
 
     def load_transactions(self) -> pd.DataFrame:
         """Load transactions from Google Sheets"""
-        self._transactions_df = self.sheets_client.get_transactions(self.sheet_name)
+        self._transactions_df = self.sheets_client.get_transactions(self.workbook_name)
         return self._transactions_df
 
     def get_transactions(self) -> Optional[pd.DataFrame]:

--- a/data/google_sheets.py
+++ b/data/google_sheets.py
@@ -8,6 +8,8 @@ from google.oauth2.service_account import Credentials
 import pandas as pd
 from typing import Dict, Optional
 
+from utils.config import WORKBOOK_NAME, WORKSHEET_NAME
+
 
 class GoogleSheetsClient:
     """Client for Google Sheets API interactions"""
@@ -48,18 +50,19 @@ class GoogleSheetsClient:
             st.error(f"❌ Error connecting to Google Sheets: {str(e)}")
             return None
 
-    def get_transactions(self, sheet_name: str) -> Optional[pd.DataFrame]:
+    def get_transactions(self, sheet_name: str = WORKBOOK_NAME) -> Optional[pd.DataFrame]:
         """
         Load transactions from Google Sheets
 
         Args:
-            sheet_name: Name of the Google Sheet
+            sheet_name: Name of the Google Sheets workbook. Defaults to the
+                configured workbook name.
 
         Returns:
             DataFrame with transaction data or None if loading fails
         """
         try:
-            sheet = self.client.open(sheet_name).worksheet("Transactions")
+            sheet = self.client.open(sheet_name).worksheet(WORKSHEET_NAME)
             data = sheet.get_all_records()
             df = pd.DataFrame(data)
 
@@ -69,11 +72,21 @@ class GoogleSheetsClient:
 
             return df
         except gspread.exceptions.SpreadsheetNotFound:
-            st.error(f"❌ Google Sheet '{sheet_name}' not found. Please check the name.")
+            st.error(
+                f"❌ Google Sheet workbook '{sheet_name}' not found. "
+                "Update the configured workbook name if needed."
+            )
             return None
         except gspread.exceptions.WorksheetNotFound:
-            st.error(f"❌ Worksheet 'Transactions' not found in '{sheet_name}'.")
+            st.error(
+                f"❌ Worksheet '{WORKSHEET_NAME}' not found in "
+                f"'{sheet_name}'. Please ensure the tab name stays exactly "
+                f"'{WORKSHEET_NAME}'."
+            )
             return None
         except Exception as e:
-            st.error(f"❌ Error loading transactions: {str(e)}")
+            st.error(
+                f"❌ Error loading transactions from workbook '{sheet_name}' "
+                f"/ worksheet '{WORKSHEET_NAME}': {str(e)}"
+            )
             return None

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -12,6 +12,7 @@ from ui.components import (
     render_manual_input_section,
     render_transactions_expander
 )
+from utils.config import WORKBOOK_ENV_VAR, WORKBOOK_JSON_PATH, WORKBOOK_NAME, WORKSHEET_NAME
 
 
 def render_sidebar() -> Dict:
@@ -19,7 +20,9 @@ def render_sidebar() -> Dict:
     Render sidebar with configuration options
 
     Returns:
-        Dictionary with configuration values
+        Dictionary with configuration values such as the uploaded credentials
+        file handle, the resolved workbook name, and whether a refresh was
+        requested.
     """
     with st.sidebar:
         st.header("⚙️ Configuration")
@@ -35,11 +38,14 @@ def render_sidebar() -> Dict:
             st.caption(f"✅ Loaded credentials file: {credentials_file.name}")
 
         st.subheader("📊 Sheet Configuration")
-        sheet_name = st.text_input(
-            "Google Sheet Name:",
-            value="Transactions",
-            help="Name of your Google Sheet (not the tab name)"
+        st.caption(
+            "Transactions are loaded from the worksheet "
+            f"**{WORKSHEET_NAME}**. Override the workbook name by setting "
+            f"`st.secrets['workbook_name']`, the `{WORKBOOK_ENV_VAR}` environment "
+            "variable, or creating a small JSON file at "
+            f"`{WORKBOOK_JSON_PATH.as_posix()}` with `{{\"workbook_name\": \"My Sheet\"}}`."
         )
+        st.info(f"Current workbook: {WORKBOOK_NAME}")
 
         st.markdown("---")
         refresh_button = st.button("🔄 Refresh Data", type="primary", use_container_width=True)
@@ -49,7 +55,7 @@ def render_sidebar() -> Dict:
 
     return {
         'credentials_file': credentials_file,
-        'sheet_name': sheet_name,
+        'workbook_name': WORKBOOK_NAME,
         'refresh_requested': refresh_button
     }
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,106 @@
+"""Application configuration helpers.
+
+This module centralizes workbook/worksheet configuration so that the Google
+Sheets workbook name can be overridden without editing the code. The worksheet
+name intentionally remains fixed to ``"Transactions"`` because the rest of the
+application expects the tab to use that name.
+
+Priority order for the workbook name:
+
+1. ``st.secrets["workbook_name"]`` if running inside Streamlit with a
+   ``.streamlit/secrets.toml`` file.
+2. ``PORTFOLIO_WORKBOOK_NAME`` environment variable.
+3. The JSON file ``config/workbook.json`` (``{"workbook_name": "..."}``).
+4. Fallback to ``"Transactions"``.
+
+The helper functions are intentionally small and dependency-free so they work
+both in the Streamlit runtime and when running unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+
+DEFAULT_WORKBOOK_NAME = "Transactions"
+WORKSHEET_NAME = "Transactions"
+
+# Environment variable that can be exported to set the workbook name.
+WORKBOOK_ENV_VAR = "PORTFOLIO_WORKBOOK_NAME"
+
+# Optional JSON configuration file relative to the project root. The JSON must
+# contain a single key called ``workbook_name``.
+WORKBOOK_JSON_PATH = Path("config/workbook.json")
+
+
+def _read_workbook_from_streamlit() -> Optional[str]:
+    """Attempt to read the workbook name from ``st.secrets``.
+
+    Returns ``None`` if Streamlit is not installed or when the key is missing.
+    """
+
+    try:  # Streamlit may not be available during unit tests.
+        import streamlit as st  # type: ignore
+    except ModuleNotFoundError:
+        return None
+
+    secrets = getattr(st, "secrets", None)
+    if secrets is None:
+        return None
+
+    try:
+        value = secrets.get("workbook_name")
+    except Exception:
+        # Accessing st.secrets can raise a RuntimeError if not initialised yet.
+        return None
+
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+
+    return None
+
+
+def _read_workbook_from_env() -> Optional[str]:
+    """Return the workbook name from the environment variable if available."""
+
+    value = os.getenv(WORKBOOK_ENV_VAR, "").strip()
+    return value or None
+
+
+def _read_workbook_from_json() -> Optional[str]:
+    """Return the workbook name from ``config/workbook.json`` if present."""
+
+    if not WORKBOOK_JSON_PATH.exists():
+        return None
+
+    try:
+        payload = json.loads(WORKBOOK_JSON_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+    value = payload.get("workbook_name") if isinstance(payload, dict) else None
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+
+    return None
+
+
+@lru_cache(maxsize=1)
+def get_workbook_name() -> str:
+    """Resolve the Google Sheets workbook name."""
+
+    return (
+        _read_workbook_from_streamlit()
+        or _read_workbook_from_env()
+        or _read_workbook_from_json()
+        or DEFAULT_WORKBOOK_NAME
+    )
+
+
+# Expose convenient module-level constants for imports elsewhere.
+WORKBOOK_NAME = get_workbook_name()
+


### PR DESCRIPTION
## Summary
- add a configuration helper that resolves the Google Sheets workbook name from secrets, environment variables, or JSON
- use the configured workbook/worksheet names across the data layer and surface them in sidebar messaging and errors
- document how to supply the workbook name in the README and sidebar copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8aa3bb5c832e86c891e5d3ec5263