### PR TITLE
Remove sidebar credential upload and rely on secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ The app will open in your browser at `http://localhost:8501`
 
 ### First Time Setup
 
-1. **Upload Credentials File**: In the sidebar, upload the Google Service Account JSON file you downloaded from Google Cloud Console
-2. **Enter Sheet Name**: Confirm or modify the Google Sheet name (default: "Transactions")
+1. **Configure Credentials**: Add your Google Service Account JSON content to `.streamlit/secrets.toml` under the key `[google_credentials]`
+2. **Provide Sheet Details**: Add your spreadsheet ID and sheet name to `st.secrets` (e.g. `google_spreadsheet_id` and `google_sheet_name`)
 3. **Click Refresh**: The app will load your transactions and fetch current market data
 
 ### Understanding the Dashboard

--- a/core/portfolio.py
+++ b/core/portfolio.py
@@ -15,43 +15,43 @@ logger = get_logger(__name__)
 class PortfolioManager:
     """Manages portfolio data and calculations"""
 
-    def __init__(self, credentials_dict: Dict, workbook_name: str, worksheet_name: str):
+    def __init__(self, credentials_dict: Dict, spreadsheet_id: str, sheet_name: str):
         """
         Initialize portfolio manager
 
         Args:
             credentials_dict: Google service account credentials
-            workbook_name: Name of the Google Sheet workbook
-            worksheet_name: Name of the worksheet/tab containing transactions
+            spreadsheet_id: Identifier of the Google Spreadsheet
+            sheet_name: Name of the worksheet/tab containing transactions
         """
         self.sheets_client = GoogleSheetsClient(credentials_dict)
         self.market_data = MarketDataProvider()
-        self.workbook_name = workbook_name
-        self.worksheet_name = worksheet_name
+        self.spreadsheet_id = spreadsheet_id
+        self.sheet_name = sheet_name
         self._transactions_df: Optional[pd.DataFrame] = None
         self._positions: Optional[Dict] = None
         logger.info(
-            "PortfolioManager created for workbook '%s' and worksheet '%s'",
-            workbook_name,
-            worksheet_name,
+            "PortfolioManager created for spreadsheet '%s' and sheet '%s'",
+            spreadsheet_id,
+            sheet_name,
         )
 
     def load_transactions(self) -> pd.DataFrame:
         """Load transactions from Google Sheets"""
         logger.info(
-            "Loading transactions for workbook '%s' / worksheet '%s'",
-            self.workbook_name,
-            self.worksheet_name,
+            "Loading transactions for spreadsheet '%s' / sheet '%s'",
+            self.spreadsheet_id,
+            self.sheet_name,
         )
         self._transactions_df = self.sheets_client.get_transactions(
-            self.workbook_name,
-            self.worksheet_name,
+            self.spreadsheet_id,
+            self.sheet_name,
         )
         if self._transactions_df is None:
             logger.warning(
-                "No transactions returned for workbook '%s' / worksheet '%s'",
-                self.workbook_name,
-                self.worksheet_name,
+                "No transactions returned for spreadsheet '%s' / sheet '%s'",
+                self.spreadsheet_id,
+                self.sheet_name,
             )
         else:
             logger.info("Loaded %d transactions", len(self._transactions_df))

--- a/ui/components.py
+++ b/ui/components.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 def show_setup_instructions():
     """Display setup instructions when credentials are not provided"""
     logger.info("Displaying setup instructions")
-    st.info("👈 Please upload your Google Sheets service account JSON file in the sidebar to get started.")
+    st.info("👈 Add your Google Sheets service account JSON to Streamlit secrets to get started.")
 
     st.markdown("""
     ### 🚀 Setup Instructions
@@ -32,13 +32,18 @@ def show_setup_instructions():
     - Click **Keys** tab > **Add Key** > **Create New Key**
     - Choose **JSON** format and download
 
-    #### 3. Share Your Google Sheet
+    #### 3. Add Credentials to Streamlit Secrets
+    - Open your `.streamlit/secrets.toml`
+    - Add a `google_credentials` entry with the JSON content
+    - Redeploy or restart the app so the new secrets are available
+
+    #### 4. Share Your Google Sheet
     - Open your Google Sheet named "Transactions"
     - Click **Share** button
     - Add the service account email (from JSON file)
     - Give **Viewer** access
 
-    #### 4. Prepare Your Sheet
+    #### 5. Prepare Your Sheet
     Your "Transactions" sheet should have these columns:
     - **Ticker**: Stock symbol or investment name
     - **Type**: BUY, SELL, or DIVIDEND

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -28,44 +28,14 @@ def render_sidebar() -> Dict:
     with st.sidebar:
         st.header("⚙️ Configuration")
 
-        st.subheader("🔐 Google Sheets Credentials")
-        credentials_file = st.file_uploader(
-            "Upload your Service Account JSON:",
-            type=["json"],
-            help="Upload the JSON key file downloaded from Google Cloud Console > IAM & Admin > Service Accounts"
-        )
-
-        if credentials_file is not None:
-            st.caption(f"✅ Loaded credentials file: {credentials_file.name}")
-            logger.info("User uploaded credentials file '%s'", credentials_file.name)
-
-        st.subheader("📊 Sheet Configuration")
-        workbook_name = st.text_input(
-            "Google Sheet (Workbook) Name:",
-            value="Transactions",
-            help="Name of your Google Sheet workbook (file)"
-        )
-        logger.debug("Workbook name input: %s", workbook_name)
-
-        worksheet_name = st.text_input(
-            "Worksheet Name:",
-            value="Transactions",
-            help="Name of the worksheet/tab containing transaction data"
-        )
-        logger.debug("Worksheet name input: %s", worksheet_name)
-
-        st.markdown("---")
         refresh_button = st.button("🔄 Refresh Data", type="primary", use_container_width=True)
         if refresh_button:
             logger.info("User requested data refresh")
 
         st.markdown("---")
-        st.caption("💡 Your credentials are never stored or shared")
+        st.caption("💡 Google Sheets credentials are loaded from Streamlit secrets")
 
     return {
-        'credentials_file': credentials_file,
-        'workbook_name': workbook_name,
-        'worksheet_name': worksheet_name,
         'refresh_requested': refresh_button
     }
 


### PR DESCRIPTION
## Summary
- remove the Google Sheets credentials uploader from the Streamlit sidebar and note that secrets are used instead
- rely exclusively on Streamlit secrets for Google credentials and update the setup instructions to match

## Testing
- python -m compileall app.py core data ui

------
https://chatgpt.com/codex/tasks/task_e_68ded214558c832e9582599370016d63