### PR TITLE
Stub position calculation pending redesign

### DIFF
--- a/ui/layout.py
+++ b/ui/layout.py
@@ -20,24 +20,14 @@ logger = get_logger(__name__)
 
 def render_sidebar() -> Dict:
     """
-    Render sidebar with configuration options
+    Render a minimal sidebar without interactive controls.
 
     Returns:
-        Dictionary with configuration values
+        An empty dictionary (placeholder for future configuration values).
     """
-    with st.sidebar:
-        st.header("⚙️ Configuration")
+    st.sidebar.empty()
 
-        refresh_button = st.button("🔄 Refresh Data", type="primary", use_container_width=True)
-        if refresh_button:
-            logger.info("User requested data refresh")
-
-        st.markdown("---")
-        st.caption("💡 Google Sheets credentials are loaded from Streamlit secrets")
-
-    return {
-        'refresh_requested': refresh_button
-    }
+    return {}
 
 
 def render_dashboard(portfolio_manager: PortfolioManager):


### PR DESCRIPTION
## Summary
- remove the inactive refresh control and sidebar messaging so the navigation only shows active content
- clean and standardize Google Sheet transactions with the data quality module
- stub out the position calculation so it simply returns an empty structure until the redesign

## Testing
- python -m compileall core ui
- python -m compileall ui/layout.py

------
https://chatgpt.com/codex/tasks/task_e_68df6b8cec8c832e9c8832b712d713bf