### PR TITLE
Fix negative current open amount calculation

### DIFF
--- a/core/portfolio.py
+++ b/core/portfolio.py
@@ -255,7 +255,9 @@ class PortfolioManager:
         summary["Weighted Avg Sell Price (EUR)"] = self._calculate_weighted_average(
             summary["sell_amount_eur"], summary["sell_quantity"]
         )
-        summary["Current Open Amount EUR"] = summary["buy_amount_eur"] - summary["sell_amount_eur"]
+        summary["Current Open Amount EUR"] = (
+            summary["buy_amount_eur"] - summary["sell_amount_eur"]
+        ).clip(lower=0)
         summary["Position Status"] = np.where(
             summary["buy_quantity"] > summary["sell_quantity"],
             "Open",


### PR DESCRIPTION
## Summary
- ensure the computed current open amount for portfolio entries is never negative by capping values at zero

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df8211ca2c832e9bcbde7ee2faef07