### PR TITLE
Add simulated current values and monthly income charts

### DIFF
--- a/core/portfolio.py
+++ b/core/portfolio.py
@@ -255,6 +255,14 @@ class PortfolioManager:
         summary["Weighted Avg Sell Price (EUR)"] = self._calculate_weighted_average(
             summary["sell_amount_eur"], summary["sell_quantity"]
         )
+
+        rng = np.random.default_rng()
+        base_buy_price = summary["Weighted Avg Buy Price (EUR)"]
+        variation = rng.uniform(0.9, 1.1, size=len(summary))
+        simulated_current_value = base_buy_price * variation
+        simulated_current_value = simulated_current_value.round(2)
+        simulated_current_value[base_buy_price.isna()] = np.nan
+        summary["current_value"] = simulated_current_value
         summary["Current Open Amount EUR"] = (
             summary["buy_amount_eur"] - summary["sell_amount_eur"]
         ).clip(lower=0)
@@ -286,6 +294,7 @@ class PortfolioManager:
             "Total Invested (EUR)",
             "Weighted Avg Buy Price (EUR)",
             "Weighted Avg Sell Price (EUR)",
+            "current_value",
             "Current Open Amount EUR",
         ]
 

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -62,7 +62,7 @@ def render_dashboard(portfolio_manager: PortfolioManager):
     with summary_tab:
         with st.spinner("🧮 Calculating weighted average costs..."):
             summary_df = portfolio_manager.calculate_weighted_average_cost()
-        render_weighted_average_cost_summary(summary_df)
+        render_weighted_average_cost_summary(summary_df, transactions_df)
 
     # Footer
     st.markdown("---")


### PR DESCRIPTION
## Summary
- simulate a current_value column for the weighted average cost table using +/-10% of the buy price
- extend the summary tab with monthly charts for interest, pension contributions, and dividends plus a pension profit input in DKK

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68df8638664c832e95c029188ccafce2