### PR TITLE
Add stock performance view with weighted profit calculations

### DIFF
--- a/ui/components.py
+++ b/ui/components.py
@@ -185,6 +185,31 @@ def render_weighted_average_cost_summary(
     render_monthly_chart("Monthly Dividends", dividends_df, "Total Dividends")
 
 
+def render_stock_view(stock_view_df: pd.DataFrame):
+    """Render the stock-centric view with profit information."""
+    st.subheader("📊 Stock View")
+
+    if stock_view_df is None or stock_view_df.empty:
+        logger.info("Stock view data frame is empty")
+        st.info("ℹ️ No stock data available to display.")
+        return
+
+    styled_df = stock_view_df.style.format(
+        {
+            "Weighted Avg Buy Price (EUR)": "€{:,.2f}",
+            "Weighted Avg Sell Price (EUR)": "€{:,.2f}",
+            "Current Value (EUR)": "€{:,.2f}",
+            "Profit (%)": "{:+.2f}%",
+        },
+        na_rep="—",
+    )
+
+    st.dataframe(styled_df, use_container_width=True)
+    st.caption(
+        "Includes realized and unrealized performance using weighted average prices and current values for open positions."
+    )
+
+
 def render_manual_input_section(tickers: List[str]):
     """
     Render manual input section for non-stock investments

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -11,6 +11,7 @@ from core.portfolio import PortfolioManager
 from ui.components import (
     render_transactions_table,
     render_weighted_average_cost_summary,
+    render_stock_view,
 )
 from utils import get_logger
 
@@ -21,6 +22,7 @@ logger = get_logger(__name__)
 TAB_LABELS = {
     "transactions": "Transactions",
     "summary": "Summary",
+    "stocks": "Stock View",
 }
 
 
@@ -53,8 +55,12 @@ def render_dashboard(portfolio_manager: PortfolioManager):
         logger.warning("No transactions data available after load")
         return
 
-    tab_names = [TAB_LABELS["transactions"], TAB_LABELS["summary"]]
-    transactions_tab, summary_tab = st.tabs(tab_names)
+    tab_names = [
+        TAB_LABELS["transactions"],
+        TAB_LABELS["summary"],
+        TAB_LABELS["stocks"],
+    ]
+    transactions_tab, summary_tab, stocks_tab = st.tabs(tab_names)
 
     with transactions_tab:
         render_transactions_table(transactions_df)
@@ -63,6 +69,11 @@ def render_dashboard(portfolio_manager: PortfolioManager):
         with st.spinner("🧮 Calculating weighted average costs..."):
             summary_df = portfolio_manager.calculate_weighted_average_cost()
         render_weighted_average_cost_summary(summary_df, transactions_df)
+
+    with stocks_tab:
+        with st.spinner("📊 Building stock view..."):
+            stock_view_df = portfolio_manager.calculate_stock_view()
+        render_stock_view(stock_view_df)
 
     # Footer
     st.markdown("---")


### PR DESCRIPTION
## Summary
- add a reusable transaction summary helper to support multiple portfolio views
- implement a stock view with weighted profit calculations and expose it in the UI
- render the new stock tab with formatted metrics and profit percentages

## Testing
- python -m compileall core ui

------
https://chatgpt.com/codex/tasks/task_e_68dfaab4bee0832e9e045cf1f344637c