### PR TITLE
Fetch real market prices and support manual overrides

### DIFF
--- a/data/market_data.py
+++ b/data/market_data.py
@@ -33,11 +33,22 @@ class MarketDataProvider:
             stock = yf.Ticker(ticker)
 
             # Try to get most recent price from history
-            hist = stock.history(period="1d")
+            hist = stock.history(period="5d")
             if not hist.empty:
-                price = float(hist['Close'].iloc[-1])
-                logger.debug("Using historical close price for '%s': %s", ticker, price)
-                return price
+                close_prices = hist["Close"].dropna()
+                if not close_prices.empty:
+                    price = float(close_prices.iloc[-1])
+                    logger.debug(
+                        "Using historical close price for '%s': %s",
+                        ticker,
+                        price,
+                    )
+                    return price
+
+            logger.debug(
+                "Historical data unavailable for '%s'; falling back to ticker info",
+                ticker,
+            )
 
             # Fallback to info
             info = stock.info

--- a/ui/components.py
+++ b/ui/components.py
@@ -104,7 +104,7 @@ def render_weighted_average_cost_summary(
         "Total Invested (EUR)": "€{:,.2f}",
         "Weighted Avg Buy Price (EUR)": "€{:,.2f}",
         "Weighted Avg Sell Price (EUR)": "€{:,.2f}",
-        "current_value": "€{:,.2f}",
+        "Current Price (EUR)": "€{:,.2f}",
         "Current Open Amount EUR": "€{:,.2f}",
     })
 

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -12,6 +12,7 @@ from ui.components import (
     render_transactions_table,
     render_weighted_average_cost_summary,
     render_stock_view,
+    render_manual_input_section,
 )
 from utils import get_logger
 
@@ -55,6 +56,9 @@ def render_dashboard(portfolio_manager: PortfolioManager):
         logger.warning("No transactions data available after load")
         return
 
+    manual_values = dict(st.session_state.get("manual_values", {}))
+    portfolio_manager.reset_missing_price_tickers()
+
     tab_names = [
         TAB_LABELS["transactions"],
         TAB_LABELS["summary"],
@@ -67,13 +71,22 @@ def render_dashboard(portfolio_manager: PortfolioManager):
 
     with summary_tab:
         with st.spinner("🧮 Calculating weighted average costs..."):
-            summary_df = portfolio_manager.calculate_weighted_average_cost()
+            summary_df = portfolio_manager.calculate_weighted_average_cost(
+                manual_values=manual_values
+            )
         render_weighted_average_cost_summary(summary_df, transactions_df)
 
     with stocks_tab:
         with st.spinner("📊 Building stock view..."):
-            stock_view_df = portfolio_manager.calculate_stock_view()
+            stock_view_df = portfolio_manager.calculate_stock_view(
+                manual_values=manual_values
+            )
         render_stock_view(stock_view_df)
+
+    missing_tickers = portfolio_manager.get_missing_price_tickers()
+    manual_input_candidates = sorted({*missing_tickers, *manual_values.keys()})
+    if manual_input_candidates:
+        render_manual_input_section(manual_input_candidates)
 
     # Footer
     st.markdown("---")


### PR DESCRIPTION
## Summary
- replace the simulated current value with real market close prices and currency conversion
- surface missing tickers in the dashboard and allow manual price overrides in the sidebar
- improve market data fetching by looking back over recent closes before falling back to ticker info

## Testing
- python -m compileall core data ui utils

------
https://chatgpt.com/codex/tasks/task_e_68dfbe135590832e8d276c3dc66661e2