### PR TITLE
Improve stock view grouping and manual price entry

### DIFF
--- a/core/portfolio.py
+++ b/core/portfolio.py
@@ -393,7 +393,6 @@ class PortfolioManager:
         summary = summary.sort_values("Current Open Amount EUR", ascending=False).reset_index(drop=True)
 
         columns_to_drop = [
-            "ticker",
             "currency",
             "sell_transactions",
             "buy_quantity",
@@ -405,6 +404,7 @@ class PortfolioManager:
 
         column_order = [
             "Name",
+            "Ticker",
             "Position Status",
             "Purchased Times",
             "Number of Shares",
@@ -414,6 +414,8 @@ class PortfolioManager:
             "Current Price (EUR)",
             "Current Open Amount EUR",
         ]
+
+        summary = summary.rename(columns={"ticker": "Ticker"})
 
         return summary[column_order]
 
@@ -483,6 +485,7 @@ class PortfolioManager:
             results.append(
                 {
                     "Name": name,
+                    "Position Status": "Open" if remaining_qty > 0 else "Closed",
                     "Weighted Avg Buy Price (EUR)": _round_or_nan(avg_buy),
                     "Weighted Avg Sell Price (EUR)": _round_or_nan(avg_sell),
                     "Current Price (EUR)": _round_or_nan(current_price_eur),
@@ -493,6 +496,17 @@ class PortfolioManager:
             )
 
         stock_view_df = pd.DataFrame(results)
+        column_order = [
+            "Name",
+            "Position Status",
+            "Weighted Avg Buy Price (EUR)",
+            "Weighted Avg Sell Price (EUR)",
+            "Current Price (EUR)",
+            "Current Value (EUR)",
+            "Profit (EUR)",
+            "Profit (%)",
+        ]
+        stock_view_df = stock_view_df[column_order]
         stock_view_df = stock_view_df.sort_values("Name").reset_index(drop=True)
         self._missing_price_tickers.update(missing_prices)
         return stock_view_df

--- a/ui/components.py
+++ b/ui/components.py
@@ -2,10 +2,13 @@
 UI Components
 Reusable UI components for the Streamlit application
 """
-import streamlit as st
-import pandas as pd
 from datetime import datetime
 from typing import List, Tuple
+import html
+
+import pandas as pd
+import streamlit as st
+
 from utils import get_logger
 
 
@@ -98,6 +101,87 @@ def render_weighted_average_cost_summary(
         st.info("ℹ️ No transactions available to compute the portfolio overview.")
         return
 
+    manual_values = st.session_state.setdefault("manual_values", {})
+
+    needs_manual_price = (
+        summary_df["Current Price (EUR)"].isna()
+        if "Current Price (EUR)" in summary_df.columns
+        else pd.Series([], dtype=bool)
+    )
+
+    if needs_manual_price.any():
+        st.markdown("### ✏️ Update Missing Prices")
+        st.caption(
+            "Enter the latest price for each highlighted row. These values will be used for future calculations."
+        )
+
+        manual_editor_df = summary_df.loc[
+            needs_manual_price,
+            [col for col in ["Name", "Ticker", "Current Price (EUR)"] if col in summary_df.columns],
+        ].copy()
+
+        if "Ticker" not in manual_editor_df.columns:
+            manual_editor_df.insert(1, "Ticker", manual_editor_df["Name"])
+
+        for idx, row in manual_editor_df.iterrows():
+            ticker = row.get("Ticker")
+            if ticker in manual_values:
+                manual_editor_df.at[idx, "Current Price (EUR)"] = manual_values.get(ticker)
+
+        st.markdown(
+            """
+            <style>
+            div[data-testid="stDataFrame"][data-st-key="summary_price_editor"] {
+                background-color: #f1f3f5;
+                border-radius: 0.75rem;
+                padding: 1rem;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
+        edited_manual_df = st.data_editor(
+            manual_editor_df,
+            column_config={
+                "Name": st.column_config.TextColumn("Name", disabled=True),
+                "Ticker": st.column_config.TextColumn(
+                    "Ticker",
+                    disabled=True,
+                    help="Identifier used for manual price overrides.",
+                ),
+                "Current Price (EUR)": st.column_config.NumberColumn(
+                    "Current Price (EUR)",
+                    help="Provide the latest price per share in EUR.",
+                    min_value=0.0,
+                    step=0.01,
+                    format="%.2f",
+                    required=True,
+                ),
+            },
+            hide_index=True,
+            key="summary_price_editor",
+            num_rows="fixed",
+        )
+
+        for _, row in edited_manual_df.iterrows():
+            ticker = row.get("Ticker")
+            price = row.get("Current Price (EUR)")
+            if not ticker:
+                continue
+            if pd.notna(price) and float(price) > 0:
+                manual_values[ticker] = float(price)
+                if "Ticker" in summary_df.columns:
+                    summary_df.loc[
+                        summary_df["Ticker"] == ticker, "Current Price (EUR)"
+                    ] = float(price)
+                else:
+                    summary_df.loc[
+                        summary_df["Name"] == row.get("Name"), "Current Price (EUR)"
+                    ] = float(price)
+            elif ticker in manual_values:
+                manual_values.pop(ticker)
+
     formatted_df = summary_df.style.format({
         "Purchased Times": "{:.0f}",
         "Number of Shares": "{:.2f}",
@@ -107,6 +191,13 @@ def render_weighted_average_cost_summary(
         "Current Price (EUR)": "€{:,.2f}",
         "Current Open Amount EUR": "€{:,.2f}",
     })
+
+    def _highlight_missing(row: pd.Series):
+        if pd.isna(row.get("Current Price (EUR)")):
+            return ["background-color: #f1f3f5"] * len(row)
+        return [""] * len(row)
+
+    formatted_df = formatted_df.apply(_highlight_missing, axis=1)
 
     st.dataframe(formatted_df, use_container_width=True)
     st.caption("Summary combines buy and sell transactions and is sorted by current open amount in EUR.")
@@ -274,34 +365,135 @@ def render_stock_view(stock_view_df: pd.DataFrame):
         st.info("ℹ️ No additional stock details available to display.")
         return
 
-    for start in range(0, len(all_stocks_df), 3):
-        columns = st.columns(3, gap="large")
-        for column, (_, stock_row) in zip(
-            columns, all_stocks_df.iloc[start : start + 3].iterrows()
-        ):
-            with column:
-                st.markdown(f"**{stock_row['Name']}**")
-                st.metric(
-                    "Profit",
-                    _format_currency(stock_row.get("Profit (EUR)")),
-                    _format_percentage(stock_row.get("Profit (%)")),
-                )
-                st.caption(
-                    " | ".join(
-                        [
-                            f"Avg Buy: {_format_currency(stock_row.get('Weighted Avg Buy Price (EUR)'))}",
-                            f"Avg Sell: {_format_currency(stock_row.get('Weighted Avg Sell Price (EUR)'))}",
-                        ]
-                    )
-                )
-                st.caption(
-                    " | ".join(
-                        [
-                            f"Current Price: {_format_currency(stock_row.get('Current Price (EUR)'))}",
-                            f"Current Value: {_format_currency(stock_row.get('Current Value (EUR)'))}",
-                        ]
-                    )
-                )
+    st.markdown(
+        """
+        <style>
+        .stock-section {
+            border-radius: 1rem;
+            padding: 1.25rem;
+            margin-bottom: 1.5rem;
+        }
+        .stock-section.open {
+            background: linear-gradient(135deg, #eef8ff 0%, #f6fbff 100%);
+        }
+        .stock-section.closed {
+            background: linear-gradient(135deg, #f7f1ff 0%, #fbf5ff 100%);
+        }
+        .stock-section h4 {
+            margin-top: 0;
+        }
+        .stock-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 1rem;
+            margin-top: 1rem;
+        }
+        .stock-card {
+            background: white;
+            border-radius: 0.85rem;
+            padding: 1rem;
+            box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .stock-card.closed {
+            background: #fff8ff;
+        }
+        .stock-card__header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-weight: 600;
+        }
+        .stock-card__label {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: #6b7280;
+        }
+        .stock-card__value {
+            font-weight: 600;
+            color: #111827;
+        }
+        .stock-card__metric {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 0.95rem;
+        }
+        .stock-card__profit-positive {
+            color: #0f9d58;
+        }
+        .stock-card__profit-negative {
+            color: #d93025;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    def _render_stock_cards(section_title: str, section_df: pd.DataFrame, section_class: str):
+        st.markdown(f"<div class='stock-section {section_class}'>", unsafe_allow_html=True)
+        st.markdown(f"<h4>{html.escape(section_title)}</h4>", unsafe_allow_html=True)
+
+        if section_df.empty:
+            st.markdown("<p>No positions in this category yet.</p>", unsafe_allow_html=True)
+            st.markdown("</div>", unsafe_allow_html=True)
+            return
+
+        cards_html = []
+        for _, stock_row in section_df.iterrows():
+            profit_value = _format_currency(stock_row.get("Profit (EUR)"))
+            profit_pct_value = _format_percentage(stock_row.get("Profit (%)"))
+            profit_class = "stock-card__profit-positive"
+            profit_number = stock_row.get("Profit (EUR)")
+            if pd.isna(profit_number) or profit_number == 0:
+                profit_class = ""
+            elif profit_number < 0:
+                profit_class = "stock-card__profit-negative"
+
+            card_html = f"""
+            <div class="stock-card {'closed' if stock_row.get('Position Status') == 'Closed' else ''}">
+                <div class="stock-card__header">
+                    <span>{html.escape(str(stock_row.get('Name', '—')))}</span>
+                    <span class="stock-card__label">{html.escape(str(stock_row.get('Position Status', '—')))}</span>
+                </div>
+                <div class="stock-card__metric">
+                    <span class="stock-card__label">Profit</span>
+                    <span class="stock-card__value {profit_class}">{html.escape(profit_value)} ({html.escape(profit_pct_value)})</span>
+                </div>
+                <div class="stock-card__metric">
+                    <span class="stock-card__label">Avg Buy</span>
+                    <span class="stock-card__value">{html.escape(_format_currency(stock_row.get('Weighted Avg Buy Price (EUR)')))}</span>
+                </div>
+                <div class="stock-card__metric">
+                    <span class="stock-card__label">Avg Sell</span>
+                    <span class="stock-card__value">{html.escape(_format_currency(stock_row.get('Weighted Avg Sell Price (EUR)')))}</span>
+                </div>
+                <div class="stock-card__metric">
+                    <span class="stock-card__label">Current Price</span>
+                    <span class="stock-card__value">{html.escape(_format_currency(stock_row.get('Current Price (EUR)')))}</span>
+                </div>
+                <div class="stock-card__metric">
+                    <span class="stock-card__label">Current Value</span>
+                    <span class="stock-card__value">{html.escape(_format_currency(stock_row.get('Current Value (EUR)')))}</span>
+                </div>
+            </div>
+            """
+            cards_html.append(card_html)
+
+        st.markdown(
+            f"<div class='stock-grid'>{''.join(cards_html)}</div>",
+            unsafe_allow_html=True,
+        )
+        st.markdown("</div>", unsafe_allow_html=True)
+
+    open_positions = all_stocks_df[all_stocks_df["Position Status"] == "Open"]
+    closed_positions = all_stocks_df[all_stocks_df["Position Status"] == "Closed"]
+
+    _render_stock_cards("Open Positions", open_positions, "open")
+    _render_stock_cards("Closed Positions", closed_positions, "closed")
 
 
 def render_manual_input_section(tickers: List[str]):


### PR DESCRIPTION
## Summary
- split the stock view into open and closed position sections with refreshed styling
- expose ticker information in the summary and enable editing missing current prices in place
- highlight rows that still require manual pricing so downstream calculations can reuse the overrides

## Testing
- python -m compileall core ui

------
https://chatgpt.com/codex/tasks/task_e_68e009dead08832e9ec54098cff87e18